### PR TITLE
Consume PRIA Warning

### DIFF
--- a/src/GSCCCA.RealEstate/FilingHandler.cs
+++ b/src/GSCCCA.RealEstate/FilingHandler.cs
@@ -412,6 +412,7 @@ namespace GSCCCA.RealEstate
             //Send the request and receive a response.
             string responseXML = PRIAAcceptPackage(requestXML);
             this.rawresponse = responseXML;
+            this.AcceptResponse = createPriaResponse(responseXML);
 
             //Analyze the response
             return processResponse(responseXML, "RECORDED");
@@ -575,6 +576,11 @@ namespace GSCCCA.RealEstate
         {
             get { return this.rawrequest; }
         }
+
+        /// <summary>
+        /// After a web method call to REService.Accept, access response object
+        /// </summary>
+        public PRIA_RESPONSE_GROUP_Type AcceptResponse { get; private set; } = default;
 
         /// <summary>
         /// Gets the raw xml response received by this FilingHandler after invoking one of the non-PRIA convenience methods

--- a/test/GSCCCA_API_DEMO/Form1.cs
+++ b/test/GSCCCA_API_DEMO/Form1.cs
@@ -511,6 +511,14 @@ namespace GSCCCA_API_DEMO
                     string response = filingManager.RawXMLResponse;
                     Console.WriteLine(response);
                 }
+                else if ("warning".Equals(filingManager.AcceptResponse.RESPONSE.First().STATUS.First()._Condition, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    // Create a warning response in this case.
+                    // This is still a success condition, but with
+                    //  an alert that should be shown to the end user
+                    //  that is found in the Status._Description.
+                    showSuccess();
+                }
                 else
                 {
                     showSuccess();

--- a/test/GSCCCA_API_DEMO/GSCCCA_API_DEMO.csproj
+++ b/test/GSCCCA_API_DEMO/GSCCCA_API_DEMO.csproj
@@ -90,6 +90,10 @@
       <Project>{3D0774D8-48A7-466A-A2BA-1E11F154966C}</Project>
       <Name>GSCCCA.RealEstate</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\PRIA Library v2.4\PRIA Library v2.4.csproj">
+      <Project>{E77F46CD-CBDC-4514-A99E-35FC24043BB5}</Project>
+      <Name>PRIA Library v2.4</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Content Include="satisfaction1.xml">


### PR DESCRIPTION
Add the ability to consume warnings from the real estate API calls and display warning description to users.