### PR TITLE
Ability to set DocumentTypeOtherDescription to Filing object

### DIFF
--- a/src/GSCCCA.RealEstate/Filing.cs
+++ b/src/GSCCCA.RealEstate/Filing.cs
@@ -38,9 +38,14 @@ namespace GSCCCA.RealEstate
         protected bool recordable = true;
 
         /// <summary>
-        /// Stores information about the doucment type represented by this filing.
+        /// Stores information about the document type represented by this filing.
         /// </summary>
         protected string documentTypeName = "";
+
+        /// <summary>
+        /// Stores information about the document description represented by this filing.
+        /// </summary>
+        protected string documentOtherTypeDescription = "";
 
         /// <summary>
         /// Endorsement information
@@ -296,9 +301,12 @@ namespace GSCCCA.RealEstate
         /// <returns>A fully populated Pria Document</returns>
         internal virtual PRIA_DOCUMENT_Type ToPriaDocument(int sequence)
         {
-            PRIA_DOCUMENT_Type doc = new PRIA_DOCUMENT_Type();
-            doc._UniqueIdentifier = this.gscccaID.ToString();
-            doc.RecordableDocumentTypeCode = (PRIA_RecordableDocumentTypeEnumerated)Enum.Parse(typeof(PRIA_RecordableDocumentTypeEnumerated), documentTypeName);
+            var doc = new PRIA_DOCUMENT_Type
+            {
+                _UniqueIdentifier = gscccaID.ToString(),
+                RecordableDocumentTypeCode = (PRIA_RecordableDocumentTypeEnumerated)Enum.Parse(typeof(PRIA_RecordableDocumentTypeEnumerated), documentTypeName),
+                RecordableDocumentTypeOtherDescription = DocumentOtherTypeDescription
+            };
 
             if (!this.recordable)
                 doc.DocumentNonRecordableIndicator = "Y";
@@ -414,6 +422,15 @@ namespace GSCCCA.RealEstate
         {
             get { return this.documentTypeName; }
             set { this.documentTypeName = value; }
+        }
+
+        /// <summary>
+        /// Gets/set the description of the document type. 
+        /// </summary>
+        public string DocumentOtherTypeDescription
+        {
+            get => string.IsNullOrEmpty(documentOtherTypeDescription) ? documentTypeName : documentOtherTypeDescription;
+            set => documentOtherTypeDescription = value;
         }
 
         /// <summary>

--- a/src/GSCCCA.RealEstate/Filing.cs
+++ b/src/GSCCCA.RealEstate/Filing.cs
@@ -305,7 +305,7 @@ namespace GSCCCA.RealEstate
             {
                 _UniqueIdentifier = gscccaID.ToString(),
                 RecordableDocumentTypeCode = (PRIA_RecordableDocumentTypeEnumerated)Enum.Parse(typeof(PRIA_RecordableDocumentTypeEnumerated), documentTypeName),
-                RecordableDocumentTypeOtherDescription = DocumentOtherTypeDescription
+                RecordableDocumentTypeOtherDescription = DocumentTypeOtherDescription
             };
 
             if (!this.recordable)
@@ -427,7 +427,7 @@ namespace GSCCCA.RealEstate
         /// <summary>
         /// Gets/set the description of the document type. 
         /// </summary>
-        public string DocumentOtherTypeDescription
+        public string DocumentTypeOtherDescription
         {
             get => string.IsNullOrEmpty(documentOtherTypeDescription) ? documentTypeName : documentOtherTypeDescription;
             set => documentOtherTypeDescription = value;

--- a/test/GSCCCA_API_DEMO/Form1.cs
+++ b/test/GSCCCA_API_DEMO/Form1.cs
@@ -470,6 +470,9 @@ namespace GSCCCA_API_DEMO
                 {
                     if (f.Recordable)
                     {
+                        // You can enter descriptive text to include with a filing.
+                        f.DocumentOtherTypeDescription = "TEST";
+
                         //Assign the endorsement info
                         f.Endorsement.Book = this.txtBook.Text;
                         f.Endorsement.Page = this.txtPage.Text;

--- a/test/GSCCCA_API_DEMO/Form1.cs
+++ b/test/GSCCCA_API_DEMO/Form1.cs
@@ -471,7 +471,7 @@ namespace GSCCCA_API_DEMO
                     if (f.Recordable)
                     {
                         // You can enter descriptive text to include with a filing.
-                        f.DocumentOtherTypeDescription = "TEST";
+                        f.DocumentTypeOtherDescription = "TEST";
 
                         //Assign the endorsement info
                         f.Endorsement.Book = this.txtBook.Text;


### PR DESCRIPTION
Ref Issue #6 

SDK users will be able to set a `DocumentTypeOtherDescription` in the `Filing` object.